### PR TITLE
Add 404 test for palette delete and add Cacade migration

### DIFF
--- a/app.js
+++ b/app.js
@@ -72,7 +72,8 @@ app.get("/api/v1/projects/:id/palettes", (req, res) => {
     })
     .catch(error => {
       res.status(500).json({ error });
-    });
+    })
+  });
 
   app.post("/api/v1/projects", (req, res) => {
     const project = req.body;
@@ -156,6 +157,7 @@ app.get("/api/v1/projects/:id/palettes", (req, res) => {
   });
 
   app.delete("/api/v1/projects/:id", (req, res) => {
+    //need a 404 sad path and or migration change so we don't need promise.all
     const deletePromises = [
       database("palettes")
         .where("project_id", req.params.id)
@@ -192,6 +194,12 @@ app.get("/api/v1/projects/:id/palettes", (req, res) => {
         res.status(500).json({ error });
       });
   });
-});
+
+
+
+
+
+
+
 
 module.exports = app;

--- a/app.test.js
+++ b/app.test.js
@@ -178,6 +178,11 @@ describe('API', () => {
             const response = await request(app).delete(`/api/v1/palettes/${selectedId}`)
             expect(response.status).toBe(204)
         })
+
+        it('should return a 404 if a request id is bad', async () => {
+            const response = await request(app).delete('/api/v1/palettes/-2')
+            expect(response.status).toBe(404)
+        })
     })
 
 })

--- a/db/migrations/20190823115853_add_cascade.js
+++ b/db/migrations/20190823115853_add_cascade.js
@@ -1,0 +1,14 @@
+
+exports.up = function(knex) {
+  return knex.schema.table('palettes', function(table) {
+    table.dropForeign('project_id')
+    table.foreign('project_id').references('projects.id').onUpdate('CASCADE').onDelete('CASCADE')
+  })
+};
+
+exports.down = function(knex) {
+  return knex.schema.table('palettes', function (table) {
+    table.dropForeign('project_id')
+    table.foreign('project_id').references('projects.id')
+  })
+}; 


### PR DESCRIPTION
One additional test for palette delete and the new migration to update the table to have cascade update and delete functionality