### PR TITLE
Query endpoint

### DIFF
--- a/app.js
+++ b/app.js
@@ -44,6 +44,25 @@ app.get("/api/v1/projects/:id", (req, res) => {
     });
 });
 
+//CUSTOM QUERY ENDPOINT TO SEARCH PROJECTS BY NAME
+app.get("/api/v1/search", (req, res) => {
+  const query = req.query.name;
+
+  database("projects")
+    .where("name", query)
+    .select()
+    .then(project => {
+      if (!project) {
+        res.status(404).json("No project found");
+      } else {
+        res.status(200).json(project);
+      }
+    })
+    .catch(error => {
+      res.status(500).json({ error });
+    });
+});
+
 app.get("/api/v1/palettes", (req, res) => {
   database("palettes")
     .select()
@@ -73,127 +92,121 @@ app.get("/api/v1/projects/:id/palettes", (req, res) => {
     .catch(error => {
       res.status(500).json({ error });
     })
-  });
+});
 
-  app.post("/api/v1/projects", (req, res) => {
-    const project = req.body;
-    for (let requiredParameter of ["name"]) {
-      if (!project[requiredParameter]) {
-        return res
-          .status(422)
-          .send({
-            error: `Expected format: { name: <String> } You're missing a "${requiredParameter}" property.`
-          });
-      }
-    }
-
-    database("projects")
-      .insert(project, "id")
-      .then(project => {
-        res.status(201).json({ id: project[0] });
+app.post("/api/v1/projects", (req, res) => {
+  const project = req.body;
+  for (let requiredParameter of ["name"]) {
+    if (!project[requiredParameter]) {
+      return res.status(422).send({
+        error: `Expected format: { name: <String> } You're missing a "${requiredParameter}" property.`
       });
-  });
-
-  app.post("/api/v1/palettes", (req, res) => {
-    const palette = req.body;
-
-    for (let requiredParameter of [
-      "name",
-      "color_one",
-      "color_two",
-      "color_three",
-      "color_four",
-      "color_five",
-      "project_id"
-    ]) {
-      if (!palette[requiredParameter]) {
-        return res
-          .status(422)
-          .send({
-            error: `Expected format: { name: <String>, color_one: <String>, color_two: <String>, color_three: <String>, color_four: <String>, color_five: <String>, project_id: <Integer>} You're missing a "${requiredParameter}" property.`
-          });
-      }
     }
+  }
 
-    database("palettes")
-      .insert(palette, "id")
-      .then(palette => {
-        res.status(201).json({ id: palette[0] });
-      })
-      .catch(error => {
-        res.status(500).json({ error });
+  database("projects")
+    .insert(project, "id")
+    .then(project => {
+      res.status(201).json({ id: project[0] });
+    })
+});
+
+app.post("/api/v1/palettes", (req, res) => {
+  const palette = req.body;
+
+  for (let requiredParameter of [
+    "name",
+    "color_one",
+    "color_two",
+    "color_three",
+    "color_four",
+    "color_five",
+    "project_id"
+  ]) {
+    if (!palette[requiredParameter]) {
+      return res.status(422).send({
+        error: `Expected format: { name: <String>, color_one: <String>, color_two: <String>, color_three: <String>, color_four: <String>, color_five: <String>, project_id: <Integer>} You're missing a "${requiredParameter}" property.`
       });
-  });
+    }
+  }
 
-  app.patch("/api/v1/projects/:id", (req, res) => {
-    if(!req.body.name) {
-      res.status(422).json('A name is required')
-    } else {
+  database("palettes")
+    .insert(palette, "id")
+    .then(palette => {
+      res.status(201).json({ id: palette[0] });
+    })
+    .catch(error => {
+      res.status(500).json({ error });
+    });
+});
+
+app.patch("/api/v1/projects/:id", (req, res) => {
+  if (!req.body.name) {
+    res.status(422).json("A name is required");
+  } else {
     database("projects")
       .where("id", req.params.id)
       .update(req.body)
       .then(project => {
-        res.status(201).json({id: project});
+        res.status(201).json({ id: project });
       })
       .catch(error => {
         res.status(500).json({ error });
       });
-    }
-  });
+  }
+});
 
-  //not sending correct msg when no req body
-  app.patch("/api/v1/palettes/:id", (req, res) => {
-    if(!req.body) {
-      res.status(422).json('A request body is required')
-    }
+//not sending correct msg when no req body
+app.patch("/api/v1/palettes/:id", (req, res) => {
+  if (!req.body) {
+    res.status(422).json("A request body is required");
+  }
 
-    database("palettes")
-      .where("id", req.params.id)
-      .update(req.body)
-      .then(palette => {
-        res.status(201).json({id: palette});
-      })
-      .catch(error => {
-        res.status(500).json({ error });
-      });
-  });
+  database("palettes")
+    .where("id", req.params.id)
+    .update(req.body)
+    .then(palette => {
+      res.status(201).json({ id: palette });
+    })
+    .catch(error => {
+      res.status(500).json({ error });
+    });
+});
 
-  app.delete("/api/v1/projects/:id", (req, res) => {
-    database("projects")
-        .where("id", req.params.id)
-        .del()
-      .then(project => {
-        if(!project) {
-          res.status(404).json('No project witht this id found')
-        } else {
+app.delete("/api/v1/projects/:id", (req, res) => {
+  database("projects")
+    .where("id", req.params.id)
+    .del()
+    .then(project => {
+      if (!project) {
+        res.status(404).json("No project witht this id found");
+      } else {
         res
           .status(204)
           .json(`Project with id ${req.params.id} has been deleted.`);
-        }
-      })
-      .catch(error => {
-        res.status(500).json({ error });
-      });
-  });
+      }
+    })
+    .catch(error => {
+      res.status(500).json({ error });
+    });
+});
 
-  app.delete("/api/v1/palettes/:id", (req, res) => {
-    database("palettes")
-      .where("id", req.params.id).del().then(palette => {
-        if(!palette) {
-          res.status(404).json('No palette with that id found')
-        } else {
-        res.status(204).json(`Palette with id ${req.params.id} has been deleted.`);
-        }
-      })
-      .catch(error => {
-        res.status(500).json({ error });
-      });
-  });
+app.delete("/api/v1/palettes/:id", (req, res) => {
+  database("palettes")
+    .where("id", req.params.id)
+    .del()
+    .then(palette => {
+      if (!palette) {
+        res.status(404).json("No palette with that id found");
+      } else {
+        res
+          .status(204)
+          .json(`Palette with id ${req.params.id} has been deleted.`);
+      }
+    })
+    .catch(error => {
+      res.status(500).json({ error });
+    });
+});
 
-  app.get("/api/v1/projects/search", (req, res) => {
-    let query = req.query.name
-
-  })
-
-  
 module.exports = app;

--- a/app.js
+++ b/app.js
@@ -94,8 +94,6 @@ app.get("/api/v1/projects/:id/palettes", (req, res) => {
       });
   });
 
-
-  //not adding a project id 
   app.post("/api/v1/palettes", (req, res) => {
     const palette = req.body;
 

--- a/app.js
+++ b/app.js
@@ -94,6 +94,8 @@ app.get("/api/v1/projects/:id/palettes", (req, res) => {
       });
   });
 
+
+  //not adding a project id 
   app.post("/api/v1/palettes", (req, res) => {
     const palette = req.body;
 
@@ -103,13 +105,14 @@ app.get("/api/v1/projects/:id/palettes", (req, res) => {
       "color_two",
       "color_three",
       "color_four",
-      "color_five"
+      "color_five",
+      "project_id"
     ]) {
       if (!palette[requiredParameter]) {
         return res
           .status(422)
           .send({
-            error: `Expected format: { name: <String>, color_one: <String>, color_two: <String>, color_three: <String>, color_four: <String>, color_five: <String> } You're missing a "${requiredParameter}" property.`
+            error: `Expected format: { name: <String>, color_one: <String>, color_two: <String>, color_three: <String>, color_four: <String>, color_five: <String>, project_id: <Integer>} You're missing a "${requiredParameter}" property.`
           });
       }
     }
@@ -140,9 +143,10 @@ app.get("/api/v1/projects/:id/palettes", (req, res) => {
     }
   });
 
+  //not sending correct msg when no req body
   app.patch("/api/v1/palettes/:id", (req, res) => {
     if(!req.body) {
-      res.status(422).json('A body is required')
+      res.status(422).json('A request body is required')
     }
 
     database("palettes")
@@ -157,20 +161,17 @@ app.get("/api/v1/projects/:id/palettes", (req, res) => {
   });
 
   app.delete("/api/v1/projects/:id", (req, res) => {
-    //need a 404 sad path and or migration change so we don't need promise.all
-    const deletePromises = [
-      database("palettes")
-        .where("project_id", req.params.id)
-        .del(),
-      database("projects")
+    database("projects")
         .where("id", req.params.id)
         .del()
-    ];
-    Promise.all(deletePromises)
       .then(project => {
+        if(!project) {
+          res.status(404).json('No project witht this id found')
+        } else {
         res
           .status(204)
           .json(`Project with id ${req.params.id} has been deleted.`);
+        }
       })
       .catch(error => {
         res.status(500).json({ error });
@@ -179,15 +180,11 @@ app.get("/api/v1/projects/:id/palettes", (req, res) => {
 
   app.delete("/api/v1/palettes/:id", (req, res) => {
     database("palettes")
-      .where("id", req.params.id)
-      .del()
-      .then(palette => {
-        if(!palette){
+      .where("id", req.params.id).del().then(palette => {
+        if(!palette) {
           res.status(404).json('No palette with that id found')
         } else {
-        res
-          .status(204)
-          .json(`Palette with id ${req.params.id} has been deleted.`);
+        res.status(204).json(`Palette with id ${req.params.id} has been deleted.`);
         }
       })
       .catch(error => {
@@ -195,11 +192,10 @@ app.get("/api/v1/projects/:id/palettes", (req, res) => {
       });
   });
 
+  app.get("/api/v1/projects/search", (req, res) => {
+    let query = req.query.name
 
+  })
 
-
-
-
-
-
+  
 module.exports = app;

--- a/app.test.js
+++ b/app.test.js
@@ -100,7 +100,7 @@ describe('API', () => {
         })
     });
 
-    //need to change test once poject id added in endpoint
+    //updated endpoint to require project_id, test may need to be revised
     describe('POST /palettes', () => {
         it.skip('should return 201 status and add new palette to the database', async () => {
             const mockPalette = {
@@ -109,7 +109,8 @@ describe('API', () => {
                 color_two:'#5f9ee5', 
                 color_three: '#f28e98', 
                 color_four:'#4740b7', 
-                color_five: '#7939da'
+                color_five: '#7939da',
+                project_id: 5
             }
 
             const response = await request(app).post('/api/v1/palettes').send(mockPalette);

--- a/app.test.js
+++ b/app.test.js
@@ -39,7 +39,6 @@ describe('API', () => {
             const expectedProject = await database('projects').select().where({ id: expectedId })
             const response = await request(app).get(`/api/v1/projects/${expectedId}`)
             const project = response.body
-
             expect(response.status).toBe(200)
             expect(project.name).toEqual(expectedProject.name)
         })
@@ -101,8 +100,9 @@ describe('API', () => {
         })
     });
 
+    //need to change test once poject id added in endpoint
     describe('POST /palettes', () => {
-        it('should return 201 status and add new palette to the database', async () => {
+        it.skip('should return 201 status and add new palette to the database', async () => {
             const mockPalette = {
                 name: 'London Fog',
                 color_one: '#bfe9d4', 
@@ -166,7 +166,7 @@ describe('API', () => {
             expect(response.status).toBe(204)
         })
 
-        it.skip('should return a 404 if a request id is bad', async () => {
+        it('should return a 404 if a request id is bad', async () => {
             const response = await request(app).delete('/api/v1/projects/-2')
             expect(response.status).toBe(404)
         })
@@ -182,6 +182,13 @@ describe('API', () => {
         it('should return a 404 if a request id is bad', async () => {
             const response = await request(app).delete('/api/v1/palettes/-2')
             expect(response.status).toBe(404)
+        })
+    })
+
+    describe('GET /projects/search', () => {
+        it('should return a 200 status code and the project by name', async () => {
+            const selectedName = await database('projects').first('name').then(object => object.name)
+            const response = await request(app).get(`/api/v1/projects/search?name=${selectedName}`)
         })
     })
 

--- a/app.test.js
+++ b/app.test.js
@@ -100,9 +100,10 @@ describe('API', () => {
         })
     });
 
-    //updated endpoint to require project_id, test may need to be revised
     describe('POST /palettes', () => {
-        it.skip('should return 201 status and add new palette to the database', async () => {
+        it('should return 201 status and add new palette to the database', async () => {
+            const mockId = await database('projects').first('id').then(object => object.id)
+            
             const mockPalette = {
                 name: 'London Fog',
                 color_one: '#bfe9d4', 
@@ -110,7 +111,7 @@ describe('API', () => {
                 color_three: '#f28e98', 
                 color_four:'#4740b7', 
                 color_five: '#7939da',
-                project_id: 5
+                project_id: mockId
             }
 
             const response = await request(app).post('/api/v1/palettes').send(mockPalette);

--- a/app.test.js
+++ b/app.test.js
@@ -16,9 +16,9 @@ describe('Server', () => {
 });
 
 describe('API', () => {
-    // beforeEach(async () => {
-    //     await database.seed.run()
-    // })
+    beforeEach(async () => {
+        await database.seed.run()
+    })
 
     describe('GET /projects', () => {
         it('should return a status of 200 and all projects', async () => {
@@ -46,6 +46,16 @@ describe('API', () => {
         it('should return 404 status if passed a bad id param', async () => {
             const response = await request(app).get('/api/v1/projects/2')
             expect(response.status).toBe(404)
+        })
+    })
+
+    //CUSTOM QUERY ENDPONT TEST
+    describe('GET /search', () => {
+        it('should return a 200 status code and the project by name', async () => {
+            const mockName = await database('projects').first('name').then(object => object.name)
+            const response = await request(app).get(`/api/v1/search?name=${mockName}`)
+            expect(response.status).toBe(200)
+            expect(response.body[0].name).toEqual(mockName)
         })
     })
 
@@ -164,6 +174,7 @@ describe('API', () => {
     describe('DELETE /projects/:id', () => {
         it('should return a 204 status code and remove project from database', async () => {
             const selectedId = await database('projects').first('id').then(object => object.id)
+            console.log(selectedId)
             const response = await request(app).delete(`/api/v1/projects/${selectedId}`)
             expect(response.status).toBe(204)
         })
@@ -184,14 +195,6 @@ describe('API', () => {
         it('should return a 404 if a request id is bad', async () => {
             const response = await request(app).delete('/api/v1/palettes/-2')
             expect(response.status).toBe(404)
-        })
-    })
-
-    describe('GET /projects/search', () => {
-        it.only('should return a 200 status code and the project by name', async () => {
-            const expectedProject = await database('projects').select().where({ name: 'Kitchen'})
-            const response = await request(app).get('/api/v1/projects/search?name=Kitchen')
-            console.log(response.body)
         })
     })
 

--- a/app.test.js
+++ b/app.test.js
@@ -16,9 +16,9 @@ describe('Server', () => {
 });
 
 describe('API', () => {
-    beforeEach(async () => {
-        await database.seed.run()
-    })
+    // beforeEach(async () => {
+    //     await database.seed.run()
+    // })
 
     describe('GET /projects', () => {
         it('should return a status of 200 and all projects', async () => {
@@ -188,9 +188,10 @@ describe('API', () => {
     })
 
     describe('GET /projects/search', () => {
-        it('should return a 200 status code and the project by name', async () => {
-            const selectedName = await database('projects').first('name').then(object => object.name)
-            const response = await request(app).get(`/api/v1/projects/search?name=${selectedName}`)
+        it.only('should return a 200 status code and the project by name', async () => {
+            const expectedProject = await database('projects').select().where({ name: 'Kitchen'})
+            const response = await request(app).get('/api/v1/projects/search?name=Kitchen')
+            console.log(response.body)
         })
     })
 


### PR DESCRIPTION
@TaylorNoelJordan  this branch has the custom endpoint /api/v1/search that allows a user to search projects by name and the test for that query. I also added the project id to the POST palette endpoint.  I think that we have all the endpoints now.

I am having a strange issue where every couple of test runs there is a seeding error that will break some tests but if you run it again it is fine and they all pass. Not sure if its related to the issues I was having with the "too many clients" errors?